### PR TITLE
chore: ptc attestations per eip-7732

### DIFF
--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -165,6 +165,12 @@ pub trait EthSpec:
     type MaxWithdrawalRequestsPerPayload: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     type MaxPendingDepositsPerEpoch: Unsigned + Clone + Sync + Send + Debug + PartialEq;
 
+    /*
+     * New in Gloas
+     */
+    type PTCSize: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type MaxPayloadAttestations: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+
     fn default_spec() -> ChainSpec;
 
     fn spec_name() -> EthSpecId;
@@ -383,6 +389,14 @@ pub trait EthSpec:
     fn proposer_lookahead_slots() -> usize {
         Self::ProposerLookaheadSlots::to_usize()
     }
+
+    fn ptc_size() -> usize {
+        Self::PTCSize::to_usize()
+    }
+
+    fn max_payload_attestations() -> usize {
+        Self::MaxPayloadAttestations::to_usize()
+    }
 }
 
 /// Macro to inherit some type values from another EthSpec.
@@ -449,6 +463,8 @@ impl EthSpec for MainnetEthSpec {
     type MaxAttestationsElectra = U8;
     type MaxWithdrawalRequestsPerPayload = U16;
     type MaxPendingDepositsPerEpoch = U16;
+    type PTCSize = U64; // todo: verify if needs to be U512 for some reason like in Mark's OG implementation
+    type MaxPayloadAttestations = U4;
 
     fn default_spec() -> ChainSpec {
         ChainSpec::mainnet()
@@ -516,7 +532,9 @@ impl EthSpec for MinimalEthSpec {
         MaxAttesterSlashingsElectra,
         MaxAttestationsElectra,
         MaxDepositRequestsPerPayload,
-        MaxWithdrawalRequestsPerPayload
+        MaxWithdrawalRequestsPerPayload,
+        PTCSize,
+        MaxPayloadAttestations
     });
 
     fn default_spec() -> ChainSpec {
@@ -584,6 +602,8 @@ impl EthSpec for GnosisEthSpec {
     type BytesPerCell = U2048;
     type KzgCommitmentsInclusionProofDepth = U4;
     type ProposerLookaheadSlots = U32; // Derived from (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH
+    type PTCSize = U64; // todo: verify if needs to be U512 for some reason like in Mark's OG implementation
+    type MaxPayloadAttestations = U4;
 
     fn default_spec() -> ChainSpec {
         ChainSpec::gnosis()

--- a/consensus/types/src/indexed_payload_attestation.rs
+++ b/consensus/types/src/indexed_payload_attestation.rs
@@ -1,0 +1,79 @@
+use crate::test_utils::TestRandom;
+use crate::*;
+use core::slice::Iter;
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use superstruct::superstruct;
+use test_random_derive::TestRandom;
+use tree_hash_derive::TreeHash;
+
+#[superstruct(
+    variants(Gloas, NextFork),
+    variant_attributes(
+        derive(
+            Debug,
+            Clone,
+            Serialize,
+            Deserialize,
+            Encode,
+            Decode,
+            TreeHash,
+            TestRandom,
+            Derivative,
+            arbitrary::Arbitrary
+        ),
+        derivative(PartialEq, Hash(bound = "E: EthSpec")),
+        serde(bound = "E: EthSpec", deny_unknown_fields),
+        arbitrary(bound = "E: EthSpec")
+    ),
+    ref_attributes(
+        derive(Debug, PartialEq, TreeHash),
+        tree_hash(enum_behaviour = "transparent")
+    )
+)]
+#[derive(
+    Debug, Clone, Serialize, Encode, Deserialize, TreeHash, Derivative, arbitrary::Arbitrary,
+)]
+#[derivative(PartialEq, Hash(bound = "E: EthSpec"))]
+#[serde(bound = "E: EthSpec", untagged)]
+#[arbitrary(bound = "E: EthSpec")]
+#[ssz(enum_behaviour = "transparent")]
+#[tree_hash(enum_behaviour = "transparent")]
+pub struct IndexedPayloadAttestation<E: EthSpec> {
+    pub attesting_indices: VariableList<u64, E::PTCSize>,
+    #[superstruct(only(Gloas), partial_getter(rename = "data_gloas"))]
+    pub data: PayloadAttestationDataGloas,
+    #[superstruct(only(NextFork), partial_getter(rename = "data_next_fork"))]
+    pub data: PayloadAttestationDataNextFork,
+    pub signature: AggregateSignature,
+}
+
+impl<E: EthSpec> IndexedPayloadAttestation<E> {
+    pub fn attesting_indices_iter(&self) -> Iter<'_, u64> {
+        self.attesting_indices().iter()
+    }
+
+    pub fn data(&self) -> PayloadAttestationDataRef {
+        match self {
+            Self::Gloas(attestation) => PayloadAttestationDataRef::Gloas(&attestation.data),
+            Self::NextFork(attestation) => PayloadAttestationDataRef::NextFork(&attestation.data),
+        }
+    }
+}
+
+impl<E: EthSpec> IndexedPayloadAttestationRef<'_, E> {
+    pub fn data(&self) -> PayloadAttestationDataRef {
+        match self {
+            Self::Gloas(attestation) => PayloadAttestationDataRef::Gloas(&attestation.data),
+            Self::NextFork(attestation) => PayloadAttestationDataRef::NextFork(&attestation.data),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ssz_and_tree_hash_tests!(IndexedPayloadAttestationGloas<MainnetEthSpec>);
+}

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -49,6 +49,7 @@ pub mod graffiti;
 pub mod historical_batch;
 pub mod historical_summary;
 pub mod indexed_attestation;
+pub mod indexed_payload_attestation;
 pub mod light_client_bootstrap;
 pub mod light_client_finality_update;
 pub mod light_client_optimistic_update;
@@ -85,6 +86,9 @@ pub mod execution_requests;
 pub mod fork_context;
 pub mod participation_flags;
 pub mod payload;
+pub mod payload_attestation;
+pub mod payload_attestation_data;
+pub mod payload_attestation_message;
 pub mod preset;
 pub mod slot_epoch;
 pub mod subnet_id;
@@ -187,6 +191,10 @@ pub use crate::historical_batch::HistoricalBatch;
 pub use crate::indexed_attestation::{
     IndexedAttestation, IndexedAttestationBase, IndexedAttestationElectra, IndexedAttestationRef,
 };
+pub use crate::indexed_payload_attestation::{
+    IndexedPayloadAttestation, IndexedPayloadAttestationGloas, IndexedPayloadAttestationNextFork,
+    IndexedPayloadAttestationRef,
+};
 pub use crate::light_client_bootstrap::{
     LightClientBootstrap, LightClientBootstrapAltair, LightClientBootstrapCapella,
     LightClientBootstrapDeneb, LightClientBootstrapElectra, LightClientBootstrapFulu,
@@ -219,6 +227,17 @@ pub use crate::payload::{
     BlindedPayloadRef, BlockType, ExecPayload, FullPayload, FullPayloadBellatrix,
     FullPayloadCapella, FullPayloadDeneb, FullPayloadElectra, FullPayloadFulu, FullPayloadGloas,
     FullPayloadRef, OwnedExecPayload,
+};
+pub use crate::payload_attestation::{
+    PayloadAttestation, PayloadAttestationGloas, PayloadAttestationNextFork, PayloadAttestationRef,
+};
+pub use crate::payload_attestation_data::{
+    PayloadAttestationData, PayloadAttestationDataGloas, PayloadAttestationDataNextFork,
+    PayloadAttestationDataRef,
+};
+pub use crate::payload_attestation_message::{
+    PayloadAttestationMessage, PayloadAttestationMessageGloas, PayloadAttestationMessageNextFork,
+    PayloadAttestationMessageRef,
 };
 pub use crate::pending_attestation::PendingAttestation;
 pub use crate::pending_consolidation::PendingConsolidation;

--- a/consensus/types/src/payload_attestation.rs
+++ b/consensus/types/src/payload_attestation.rs
@@ -1,0 +1,74 @@
+use crate::test_utils::TestRandom;
+use crate::*;
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use superstruct::superstruct;
+use test_random_derive::TestRandom;
+use tree_hash_derive::TreeHash;
+
+#[superstruct(
+    variants(Gloas, NextFork),
+    variant_attributes(
+        derive(
+            Debug,
+            Clone,
+            Serialize,
+            Deserialize,
+            Encode,
+            Decode,
+            TreeHash,
+            TestRandom,
+            Derivative,
+            arbitrary::Arbitrary
+        ),
+        derivative(PartialEq, Hash(bound = "E: EthSpec")),
+        serde(bound = "E: EthSpec", deny_unknown_fields),
+        arbitrary(bound = "E: EthSpec")
+    ),
+    ref_attributes(
+        derive(Debug, PartialEq, TreeHash),
+        tree_hash(enum_behaviour = "transparent")
+    )
+)]
+#[derive(
+    Debug, Clone, Serialize, Encode, Deserialize, TreeHash, Derivative, arbitrary::Arbitrary,
+)]
+#[derivative(PartialEq, Hash(bound = "E: EthSpec"))]
+#[serde(bound = "E: EthSpec", untagged, deny_unknown_fields)]
+#[arbitrary(bound = "E: EthSpec")]
+#[ssz(enum_behaviour = "transparent")]
+#[tree_hash(enum_behaviour = "transparent")]
+pub struct PayloadAttestation<E: EthSpec> {
+    pub aggregation_bits: BitList<E::PTCSize>,
+    #[superstruct(only(Gloas), partial_getter(rename = "data_gloas"))]
+    pub data: PayloadAttestationDataGloas,
+    #[superstruct(only(NextFork), partial_getter(rename = "data_next_fork"))]
+    pub data: PayloadAttestationDataNextFork,
+    pub signature: AggregateSignature,
+}
+
+impl<E: EthSpec> PayloadAttestation<E> {
+    pub fn data(&self) -> PayloadAttestationDataRef {
+        match self {
+            Self::Gloas(attestation) => PayloadAttestationDataRef::Gloas(&attestation.data),
+            Self::NextFork(attestation) => PayloadAttestationDataRef::NextFork(&attestation.data),
+        }
+    }
+}
+
+impl<E: EthSpec> PayloadAttestationRef<'_, E> {
+    pub fn data(&self) -> PayloadAttestationDataRef {
+        match self {
+            Self::Gloas(attestation) => PayloadAttestationDataRef::Gloas(&attestation.data),
+            Self::NextFork(attestation) => PayloadAttestationDataRef::NextFork(&attestation.data),
+        }
+    }
+}
+
+#[cfg(test)]
+mod payload_attestation_tests {
+    use super::*;
+
+    ssz_and_tree_hash_tests!(PayloadAttestationGloas<MinimalEthSpec>);
+}

--- a/consensus/types/src/payload_attestation_data.rs
+++ b/consensus/types/src/payload_attestation_data.rs
@@ -1,0 +1,75 @@
+use crate::test_utils::TestRandom;
+use crate::*;
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use superstruct::superstruct;
+use test_random_derive::TestRandom;
+use tree_hash_derive::TreeHash;
+
+/// The data upon which a ptc attestation is based.
+#[superstruct(
+    variants(Gloas, NextFork),
+    variant_attributes(
+        derive(
+            Debug,
+            Clone,
+            Serialize,
+            Deserialize,
+            Encode,
+            Decode,
+            TreeHash,
+            TestRandom,
+            Derivative,
+            arbitrary::Arbitrary
+        ),
+        derivative(PartialEq, Hash),
+        serde(deny_unknown_fields)
+    ),
+    ref_attributes(
+        derive(Debug, PartialEq, TreeHash),
+        tree_hash(enum_behaviour = "transparent")
+    )
+)]
+#[derive(
+    Debug, Clone, Serialize, Encode, Deserialize, TreeHash, Derivative, arbitrary::Arbitrary,
+)]
+#[derivative(PartialEq, Hash)]
+#[serde(untagged, deny_unknown_fields)]
+#[ssz(enum_behaviour = "transparent")]
+#[tree_hash(enum_behaviour = "transparent")]
+pub struct PayloadAttestationData {
+    pub beacon_block_root: Hash256,
+    pub slot: Slot,
+    #[superstruct(only(Gloas), partial_getter(rename = "payload_status_gloas"))]
+    pub payload_status: bool,
+    #[superstruct(only(NextFork), partial_getter(rename = "payload_status_next_fork"))]
+    pub payload_status: bool,
+}
+
+impl SignedRoot for PayloadAttestationData {}
+
+impl PayloadAttestationData {
+    pub fn payload_status(&self) -> bool {
+        match self {
+            Self::Gloas(data) => data.payload_status,
+            Self::NextFork(data) => data.payload_status,
+        }
+    }
+}
+
+impl<'a> PayloadAttestationDataRef<'a> {
+    pub fn payload_status(&self) -> bool {
+        match self {
+            Self::Gloas(data) => data.payload_status,
+            Self::NextFork(data) => data.payload_status,
+        }
+    }
+}
+
+#[cfg(test)]
+mod payload_attestation_data_tests {
+    use super::*;
+
+    ssz_and_tree_hash_tests!(PayloadAttestationDataGloas);
+}

--- a/consensus/types/src/payload_attestation_message.rs
+++ b/consensus/types/src/payload_attestation_message.rs
@@ -1,0 +1,73 @@
+use crate::test_utils::TestRandom;
+use crate::*;
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use superstruct::superstruct;
+use test_random_derive::TestRandom;
+use tree_hash_derive::TreeHash;
+
+#[superstruct(
+    variants(Gloas, NextFork),
+    variant_attributes(
+        derive(
+            Debug,
+            Clone,
+            Serialize,
+            Deserialize,
+            Encode,
+            Decode,
+            TreeHash,
+            TestRandom,
+            Derivative,
+            arbitrary::Arbitrary
+        ),
+        derivative(PartialEq, Hash),
+        serde(deny_unknown_fields)
+    ),
+    ref_attributes(
+        derive(Debug, PartialEq, TreeHash),
+        tree_hash(enum_behaviour = "transparent")
+    )
+)]
+#[derive(
+    Debug, Clone, Serialize, Encode, Deserialize, TreeHash, Derivative, arbitrary::Arbitrary,
+)]
+#[derivative(PartialEq, Hash)]
+#[serde(untagged, deny_unknown_fields)]
+#[ssz(enum_behaviour = "transparent")]
+#[tree_hash(enum_behaviour = "transparent")]
+pub struct PayloadAttestationMessage {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    #[superstruct(only(Gloas), partial_getter(rename = "data_gloas"))]
+    pub data: PayloadAttestationDataGloas,
+    #[superstruct(only(NextFork), partial_getter(rename = "data_next_fork"))]
+    pub data: PayloadAttestationDataNextFork,
+    pub signature: Signature, // todo(eip-7732): verify if should be Signature or AggregateSignature. thinking Signature since this message is just signed by a single validator
+}
+
+impl PayloadAttestationMessage {
+    pub fn data(&self) -> PayloadAttestationDataRef {
+        match self {
+            Self::Gloas(message) => PayloadAttestationDataRef::Gloas(&message.data),
+            Self::NextFork(message) => PayloadAttestationDataRef::NextFork(&message.data),
+        }
+    }
+}
+
+impl<'a> PayloadAttestationMessageRef<'a> {
+    pub fn data(&self) -> PayloadAttestationDataRef {
+        match self {
+            Self::Gloas(message) => PayloadAttestationDataRef::Gloas(&message.data),
+            Self::NextFork(message) => PayloadAttestationDataRef::NextFork(&message.data),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ssz_and_tree_hash_tests!(PayloadAttestationMessageGloas);
+}


### PR DESCRIPTION
## Changes
- Added containers `PayloadAttestationData`, `PayloadAttestation`, `PayloadAttestationMessage`, and `IndexedPayloadAttestation` per [spec](https://ethereum.github.io/consensus-specs/specs/_features/eip7732/beacon-chain/#payloadattestationmessage) as superstructs

ssz + tree hash tests passed via `cargo test --package types`

@ethDreamer, lmk if the superstruct implementations for each `PayloadAttestation*` is what you were thinking on the call. Happy to refactor or embellish in any way

Lmk if should extend the `PayloadAttestation` implementations with the following:
- sig verification logic
- attestation aggregation support
- payload processing
- networking support

Or if rather keep these superstructs simple for now and move onto other containers